### PR TITLE
Better logging for bad auth payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-health/bridge",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "description": "Official SDK for Source Health iframe plugins.",
   "scripts": {

--- a/src/SourceBridge.ts
+++ b/src/SourceBridge.ts
@@ -118,6 +118,10 @@ class SourceBridgeAPI {
 
   private handleNewAuth(auth: AuthPayload): void {
     console.log('[SourceBridge] handling new application token.')
+    if (!auth.token || !auth.expires_at) {
+      console.error('[SourceBridge] could not parse new application token')
+      return
+    }
     this.auth = {
       token: auth.token,
       expiresAt: new Date(auth.expires_at),


### PR DESCRIPTION
Only overwrite the new token if it's as expected. Log as an error if we get something improper.